### PR TITLE
Fix struct handling

### DIFF
--- a/CasCore/GuardExpressionVisitor.cs
+++ b/CasCore/GuardExpressionVisitor.cs
@@ -106,7 +106,7 @@ internal class GuardExpressionVisitor : ExpressionVisitor
     {
         if (node.Constructor is null)
         {
-            throw new SecurityException("Compiling System.Linq.Expressions.NewExpression with null constructor not supported in CAS contexts.");
+            return node;
         }
         else if (node.Members is null)
         {

--- a/CasCore/GuardExpressionVisitor.cs
+++ b/CasCore/GuardExpressionVisitor.cs
@@ -39,7 +39,7 @@ internal class GuardExpressionVisitor : ExpressionVisitor
         }
         else
         {
-            return VisitBinary(node);
+            return node;
         }
     }
 

--- a/CasCore/MethodShims.cs
+++ b/CasCore/MethodShims.cs
@@ -149,7 +149,7 @@ public static class MethodShims
     [StaticShim(typeof(Activator))]
     public static T CreateInstance<T>()
     {
-        if (!typeof(T).IsPrimitive)
+        if (!typeof(T).IsPrimitive && typeof(T).GetConstructors().Length > 0)
         {
             var constructor = typeof(T).GetConstructor([]);
 
@@ -183,7 +183,7 @@ public static class MethodShims
 
     private static object? CreateInstance(Assembly assembly, Type type, bool nonPublic)
     {
-        if (!type.IsPrimitive)
+        if (!type.IsPrimitive && type.GetConstructors().Length > 0)
         {
             ArgumentNullException.ThrowIfNull(type);
             var constructor = type.GetConstructor([]);


### PR DESCRIPTION
As discussed previously over email, this PR fixes:

1. Handling cases where Constructor is null in both NewExpression and constructor shims.
2. Infinite recursion when visiting method-less BinaryExpression.